### PR TITLE
Market Asks/BidsGenerator service messages 'a' and 'k' fields should be float

### DIFF
--- a/robonomics_market/srv/AsksGenerator.srv
+++ b/robonomics_market/srv/AsksGenerator.srv
@@ -1,5 +1,5 @@
-int32 a
-int32 k
+float64 a
+float64 k
 string market
 string objective
 uint32 fee

--- a/robonomics_market/srv/BidsGenerator.srv
+++ b/robonomics_market/srv/BidsGenerator.srv
@@ -1,5 +1,5 @@
-int32 a
-int32 k
+float64 a
+float64 k
 string market
 uint32 fee
 uint32 price_range


### PR DESCRIPTION
One of ask law I have: Q = 5 - 0.06 * P, where a = 5,  k = 0.06. There is no way to publish it with integer 'k'.
Changes tested with matcher and different 'a' and 'k' values, seems ok.