### PR TITLE
Drop non-integer count lot instead of round it

### DIFF
--- a/robonomics_market/src/robonomics_market/generator.py
+++ b/robonomics_market/src/robonomics_market/generator.py
@@ -44,9 +44,10 @@ class Generator:
         msg.objective = objective
         msg.fee       = fee
         for P in range(1, price_range):
-            msg.cost  = P
-            msg.count = int(a - k * P)
-            if msg.count > 0:
+            count = a - k * P
+            if count > 0 and count % 1 == 0:
+                msg.cost  = P
+                msg.count = int(count)
                 self.signing_ask.publish(msg)
 
     def gen_linear_bids(self, a, k, market, fee, price_range):
@@ -57,7 +58,8 @@ class Generator:
         msg.model = market
         msg.fee   = fee
         for P in range(1, price_range):
-            msg.cost  = P
-            msg.count = int(a + k * P)
-            if msg.count > 0:
+            count = a + k * P
+            if count > 0 and count % 1 == 0:
+                msg.cost  = P
+                msg.count = int(count)
                 self.signing_bid.publish(msg)


### PR DESCRIPTION
To restrict publishing multiple lots with different price and the same lot size (count) by one law, lots with non-integer size have to be prohibited but not published with rounded price.