### PR TITLE
Executor race condition and ethereum account param

### DIFF
--- a/robonomics_liability/launch/liability.launch
+++ b/robonomics_liability/launch/liability.launch
@@ -4,6 +4,7 @@
   <arg name="ipfs_http_provider" default="http://127.0.0.1:5001" />
   <arg name="builder_contract_address" default="0x673b9e3b800123E95B1582c97964812389E8040C" />
   <arg name="run_liability_immediately" default="true" />
+  <arg name="eth_account_address" default="" />
 
   <!-- liability group -->
   <group ns="liability">
@@ -19,6 +20,7 @@
       <param name="run_liability_immediately" value="$(arg run_liability_immediately)" />
       <param name="web3_http_provider" value="$(arg web3_http_provider)" />
       <param name="ipfs_http_provider" value="$(arg ipfs_http_provider)" />
+      <param name="eth_account_address" value="$(arg eth_account_address)" />
     </node>
   </group>
 </launch>

--- a/robonomics_liability/launch/liability.launch
+++ b/robonomics_liability/launch/liability.launch
@@ -21,7 +21,8 @@
       <param name="run_liability_immediately" value="$(arg run_liability_immediately)" />
       <param name="web3_http_provider" value="$(arg web3_http_provider)" />
       <param name="ipfs_http_provider" value="$(arg ipfs_http_provider)" />
-      <param name="eth_account_address" value="$(arg eth_account_address)" />
+      <param name="eth_account_address" value="$(arg eth_account_address)"
+             if="$(eval len(arg('eth_account_address')) > 0)"/>
     </node>
   </group>
 </launch>

--- a/robonomics_liability/launch/liability.launch
+++ b/robonomics_liability/launch/liability.launch
@@ -4,6 +4,7 @@
   <arg name="ipfs_http_provider" default="http://127.0.0.1:5001" />
   <arg name="builder_contract_address" default="0x673b9e3b800123E95B1582c97964812389E8040C" />
   <arg name="run_liability_immediately" default="true" />
+  <arg name="enable_executor" default="true" />
   <arg name="eth_account_address" default="" />
 
   <!-- liability group -->
@@ -16,7 +17,7 @@
       <param name="ipfs_http_provider" value="$(arg ipfs_http_provider)" />
     </node>
 
-    <node pkg="robonomics_liability" type="executor_node" name="executor" output="screen">
+    <node pkg="robonomics_liability" type="executor_node" name="executor" output="screen" if="$(arg enable_executor)">
       <param name="run_liability_immediately" value="$(arg run_liability_immediately)" />
       <param name="web3_http_provider" value="$(arg web3_http_provider)" />
       <param name="ipfs_http_provider" value="$(arg ipfs_http_provider)" />

--- a/robonomics_liability/src/robonomics_liability/executor.py
+++ b/robonomics_liability/src/robonomics_liability/executor.py
@@ -28,8 +28,7 @@ class Executor:
         web3_provider = rospy.get_param('~web3_http_provider')
         self.web3 = Web3(HTTPProvider(web3_provider))
 
-        self.account = rospy.get_param('~eth_account_address')
-        self.account = self.web3.eth.accounts[0] if len(self.account) == 0 else self.account
+        self.account = rospy.get_param('~eth_account_address', self.web3.eth.accounts[0])
 
         ipfs_provider = urlparse(rospy.get_param('~ipfs_http_provider')).netloc.split(':')
         self.ipfs = ipfsapi.connect(ipfs_provider[0], int(ipfs_provider[1]))

--- a/robonomics_liability/src/robonomics_liability/executor.py
+++ b/robonomics_liability/src/robonomics_liability/executor.py
@@ -4,6 +4,7 @@
 #
 
 from robonomics_liability.msg import Liability
+from robonomics_lighthouse.msg import Result
 from std_srvs.srv import Empty, EmptyResponse
 from tempfile import TemporaryDirectory 
 from web3 import Web3, HTTPProvider
@@ -48,6 +49,7 @@ class Executor:
 
         self.complete = rospy.Publisher('complete', Liability, queue_size=10)
         self.current  = rospy.Publisher('current', Liability, queue_size=10)
+        self.result_topic = rospy.Publisher('result', Result, queue_size=10)
 
     def _liability_worker(self):
         while not rospy.is_shutdown():
@@ -79,7 +81,12 @@ class Executor:
                     rospy.sleep(1)
 
                 msg.result = self.ipfs.add(result_file)['Hash']
+                result_msg = Result()
+                result_msg.liability = msg.address
+                result_msg.result = msg.result
+
                 self.complete.publish(msg)
+                self.result_topic.publish(result_msg)
                 rospy.loginfo('Liability %s finished with %s', msg.address, msg.result)
 
     def spin(self):

--- a/robonomics_liability/src/robonomics_liability/executor.py
+++ b/robonomics_liability/src/robonomics_liability/executor.py
@@ -80,6 +80,7 @@ class Executor:
                 while not self.liability_finish:
                     rospy.sleep(1)
 
+                recorder.stop()
                 msg.result = self.ipfs.add(result_file)['Hash']
                 result_msg = Result()
                 result_msg.liability = msg.address

--- a/robonomics_liability/src/robonomics_liability/executor.py
+++ b/robonomics_liability/src/robonomics_liability/executor.py
@@ -26,7 +26,9 @@ class Executor:
 
         web3_provider = rospy.get_param('~web3_http_provider')
         self.web3 = Web3(HTTPProvider(web3_provider))
-        self.account = self.web3.eth.accounts[0]
+
+        self.account = rospy.get_param('~eth_account_address')
+        self.account = self.web3.eth.accounts[0] if len(self.account) == 0 else self.account
 
         ipfs_provider = urlparse(rospy.get_param('~ipfs_http_provider')).netloc.split(':')
         self.ipfs = ipfsapi.connect(ipfs_provider[0], int(ipfs_provider[1]))

--- a/robonomics_liability/src/robonomics_liability/recorder.py
+++ b/robonomics_liability/src/robonomics_liability/recorder.py
@@ -118,6 +118,8 @@ class Recorder(object):
             self._stop_condition.notify_all()
         
         self._write_queue.put(self)
+        self._master_check_thread.join()
+        self._write_thread.join()
 
     ## Implementation
 

--- a/robonomics_lighthouse/launch/infochan.launch
+++ b/robonomics_lighthouse/launch/infochan.launch
@@ -5,6 +5,7 @@
   <arg name="lighthouse_contract" default="0x9c8DD1E767f54520B4fb1A6E306F172EA8492f9c" />
   <arg name="enable_generator" default="false" />
   <arg name="enable_signer" default="true" />
+  <arg name="eth_account_address" default="" />
 
   <!-- market group -->
   <group ns="infochan">
@@ -15,6 +16,7 @@
 
     <node pkg="robonomics_lighthouse" type="signer_node" name="signer" if="$(arg enable_signer)" output="screen">
       <param name="web3_http_provider" value="$(arg web3_http_provider)" />
+      <param name="eth_account_address" value="$(arg eth_account_address)" />
     </node>
 
     <node pkg="robonomics_lighthouse" type="generator_node" name="generator" if="$(arg enable_generator)" />

--- a/robonomics_lighthouse/launch/infochan.launch
+++ b/robonomics_lighthouse/launch/infochan.launch
@@ -16,7 +16,8 @@
 
     <node pkg="robonomics_lighthouse" type="signer_node" name="signer" if="$(arg enable_signer)" output="screen">
       <param name="web3_http_provider" value="$(arg web3_http_provider)" />
-      <param name="eth_account_address" value="$(arg eth_account_address)" />
+      <param name="eth_account_address" value="$(arg eth_account_address)"
+             if="$(eval len(arg('eth_account_address')) > 0)"/>
     </node>
 
     <node pkg="robonomics_lighthouse" type="generator_node" name="generator" if="$(arg enable_generator)" />

--- a/robonomics_lighthouse/launch/lighthouse.launch
+++ b/robonomics_lighthouse/launch/lighthouse.launch
@@ -18,7 +18,8 @@
       <param name="web3_http_provider" value="$(arg web3_http_provider)" />
       <param name="builder_abi" textfile="$(find robonomics_lighthouse)/abi/factory.json" />
       <param name="builder_contract" value="$(arg lighthouse_contract)" />
-      <param name="eth_account_address" value="$(arg eth_account_address)" />
+      <param name="eth_account_address" value="$(arg eth_account_address)"
+             if="$(eval len(arg('eth_account_address')) > 0)"/>
     </node>
 
     <node pkg="robonomics_lighthouse" type="reporter_node" name="reporter" output="screen">
@@ -26,7 +27,8 @@
       <param name="lighthouse_contract" value="$(arg lighthouse_contract)" />
       <param name="liability_abi" textfile="$(find robonomics_lighthouse)/abi/liability.json" />
       <param name="lighthouse_abi" textfile="$(find robonomics_lighthouse)/abi/lighthouse.json" />
-      <param name="eth_account_address" value="$(arg eth_account_address)" />
+      <param name="eth_account_address" value="$(arg eth_account_address)"
+             if="$(eval len(arg('eth_account_address')) > 0)"/>
     </node>
   </group>
 </launch>

--- a/robonomics_lighthouse/launch/lighthouse.launch
+++ b/robonomics_lighthouse/launch/lighthouse.launch
@@ -3,6 +3,7 @@
   <arg name="web3_http_provider" default="http://localhost:8545" />
   <arg name="ipfs_http_provider" default="http://127.0.0.1:5001" />
   <arg name="lighthouse_contract" default="0x9c8DD1E767f54520B4fb1A6E306F172EA8492f9c" />
+  <arg name="eth_account_address" default="" />
 
   <!-- market group -->
   <group ns="lighthouse">
@@ -17,6 +18,7 @@
       <param name="web3_http_provider" value="$(arg web3_http_provider)" />
       <param name="builder_abi" textfile="$(find robonomics_lighthouse)/abi/factory.json" />
       <param name="builder_contract" value="$(arg lighthouse_contract)" />
+      <param name="eth_account_address" value="$(arg eth_account_address)" />
     </node>
 
     <node pkg="robonomics_lighthouse" type="reporter_node" name="reporter" output="screen">
@@ -24,6 +26,7 @@
       <param name="lighthouse_contract" value="$(arg lighthouse_contract)" />
       <param name="liability_abi" textfile="$(find robonomics_lighthouse)/abi/liability.json" />
       <param name="lighthouse_abi" textfile="$(find robonomics_lighthouse)/abi/lighthouse.json" />
+      <param name="eth_account_address" value="$(arg eth_account_address)" />
     </node>
   </group>
 </launch>

--- a/robonomics_lighthouse/msg/Result.msg
+++ b/robonomics_lighthouse/msg/Result.msg
@@ -1,6 +1,6 @@
 # Result liability
 string liability     # address
 # Result IPFS hash
-uint8[] result       # hex
+string result       # base58
 # Result signature
 uint8[] signature    # hex

--- a/robonomics_lighthouse/src/robonomics_lighthouse/infochan.py
+++ b/robonomics_lighthouse/src/robonomics_lighthouse/infochan.py
@@ -34,7 +34,7 @@ def ask2dict(a):
 
 def res2dict(r):
     return { 'liability' : r.liability, 
-             'result'    : hexlify(r.result).decode('utf-8'),
+             'result'    : r.result,
              'signature' : hexlify(r.signature).decode('utf-8') }
 
 class InfoChan:
@@ -92,7 +92,7 @@ class InfoChan:
             for m in subscribe(self.ipfs_api, self.result_chan):
                 msg = Result()
                 msg.liability = m['liability']
-                msg.result    = unhexlify(m['result'].encode('utf-8'))
+                msg.result    = m['result']
                 msg.signature = unhexlify(m['signature'].encode('utf-8'))
                 self.incoming_res.publish(msg)
 

--- a/robonomics_lighthouse/src/robonomics_lighthouse/matcher.py
+++ b/robonomics_lighthouse/src/robonomics_lighthouse/matcher.py
@@ -29,8 +29,7 @@ class Matcher:
         builder_address = rospy.get_param('~builder_contract')
         self.builder = self.web3.eth.contract(builder_address, abi=builder_abi)
 
-        self.account = rospy.get_param('~eth_account_address')
-        self.account = self.web3.eth.accounts[0] if len(self.account) == 0 else self.account
+        self.account = rospy.get_param('~eth_account_address', self.web3.eth.accounts[0])
 
         rospy.Subscriber('infochan/incoming/bid', Bid, lambda x: self.match(bid=x))
         rospy.Subscriber('infochan/incoming/ask', Ask, lambda x: self.match(ask=x))

--- a/robonomics_lighthouse/src/robonomics_lighthouse/matcher.py
+++ b/robonomics_lighthouse/src/robonomics_lighthouse/matcher.py
@@ -29,6 +29,9 @@ class Matcher:
         builder_address = rospy.get_param('~builder_contract')
         self.builder = self.web3.eth.contract(builder_address, abi=builder_abi)
 
+        self.account = rospy.get_param('~eth_account_address')
+        self.account = self.web3.eth.accounts[0] if len(self.account) == 0 else self.account
+
         rospy.Subscriber('infochan/incoming/bid', Bid, lambda x: self.match(bid=x))
         rospy.Subscriber('infochan/incoming/ask', Ask, lambda x: self.match(ask=x))
 
@@ -90,7 +93,7 @@ class Matcher:
                , bid.signature[0:32]
                , bid.signature[32:64] ]
         deadline = [ ask.deadline, bid.deadline ]
-        self.builder.transact({'gas': 1000000}).createLiability(
+        self.builder.transact({'gas': 1000000, 'from': self.account}).createLiability(
                 b58decode(ask.model)[2:],
                 b58decode(ask.objective)[2:],
                 ask.token,

--- a/robonomics_lighthouse/src/robonomics_lighthouse/reporter.py
+++ b/robonomics_lighthouse/src/robonomics_lighthouse/reporter.py
@@ -23,6 +23,9 @@ class Reporter:
         lighthouse_address = rospy.get_param('~lighthouse_contract')
         self.lighthouse = self.web3.eth.contract(lighthouse_address, abi=lighthouse_abi)
 
+        self.account = rospy.get_param('~eth_account_address')
+        self.account = self.web3.eth.accounts[0] if len(self.account) == 0 else self.account
+
         rospy.Subscriber('infochan/incoming/result', Result, self.settlement)
 
     def spin(self):
@@ -38,5 +41,5 @@ class Reporter:
         v, r, s = msg.signature[64], msg.signature[0:32], msg.signature[32:64]
         liability = self.web3.eth.contract(msg.liability, abi=self.liability_abi)
         data = liability.functions.setResult(msg.result, v, r, s).buildTransaction({'gas': 1000000})['data'] 
-        self.lighthouse.transact({'gas': 300000}).to(msg.liability, data)
+        self.lighthouse.transact({'gas': 300000, 'from': self.account}).to(msg.liability, data)
         rospy.loginfo('Result submitted with data: {0}'.format(data))

--- a/robonomics_lighthouse/src/robonomics_lighthouse/reporter.py
+++ b/robonomics_lighthouse/src/robonomics_lighthouse/reporter.py
@@ -6,6 +6,7 @@
 from robonomics_lighthouse.msg import Result
 from web3 import Web3, HTTPProvider
 from binascii import hexlify, unhexlify
+from base58 import b58decode
 import rospy, json
 
 class Reporter:
@@ -40,6 +41,6 @@ class Reporter:
         '''
         v, r, s = msg.signature[64], msg.signature[0:32], msg.signature[32:64]
         liability = self.web3.eth.contract(msg.liability, abi=self.liability_abi)
-        data = liability.functions.setResult(msg.result, v, r, s).buildTransaction({'gas': 1000000})['data'] 
+        data = liability.functions.setResult(b58decode(msg.result)[2:], v, r, s).buildTransaction({'gas': 1000000})['data']
         self.lighthouse.transact({'gas': 300000, 'from': self.account}).to(msg.liability, data)
         rospy.loginfo('Result submitted with data: {0}'.format(data))

--- a/robonomics_lighthouse/src/robonomics_lighthouse/reporter.py
+++ b/robonomics_lighthouse/src/robonomics_lighthouse/reporter.py
@@ -24,8 +24,7 @@ class Reporter:
         lighthouse_address = rospy.get_param('~lighthouse_contract')
         self.lighthouse = self.web3.eth.contract(lighthouse_address, abi=lighthouse_abi)
 
-        self.account = rospy.get_param('~eth_account_address')
-        self.account = self.web3.eth.accounts[0] if len(self.account) == 0 else self.account
+        self.account = rospy.get_param('~eth_account_address', self.web3.eth.accounts[0])
 
         rospy.Subscriber('infochan/incoming/result', Result, self.settlement)
 

--- a/robonomics_lighthouse/src/robonomics_lighthouse/signer.py
+++ b/robonomics_lighthouse/src/robonomics_lighthouse/signer.py
@@ -56,8 +56,7 @@ class Signer:
         rospy.init_node('robonomics_signer')
         http_provider = rospy.get_param('~web3_http_provider')
         self.web3     = Web3(HTTPProvider(http_provider))
-        self.account = rospy.get_param('~eth_account_address')
-        self.account = self.web3.eth.accounts[0] if len(self.account) == 0 else self.account
+        self.account = rospy.get_param('~eth_account_address', self.web3.eth.accounts[0])
 
         self.signed_ask = rospy.Publisher('sending/ask', Ask, queue_size=10)
         self.signed_bid = rospy.Publisher('sending/bid', Bid, queue_size=10)

--- a/robonomics_lighthouse/src/robonomics_lighthouse/signer.py
+++ b/robonomics_lighthouse/src/robonomics_lighthouse/signer.py
@@ -56,7 +56,8 @@ class Signer:
         rospy.init_node('robonomics_signer')
         http_provider = rospy.get_param('~web3_http_provider')
         self.web3     = Web3(HTTPProvider(http_provider))
-        self.account  = self.web3.eth.accounts[0]
+        self.account = rospy.get_param('~eth_account_address')
+        self.account = self.web3.eth.accounts[0] if len(self.account) == 0 else self.account
 
         self.signed_ask = rospy.Publisher('sending/ask', Ask, queue_size=10)
         self.signed_bid = rospy.Publisher('sending/bid', Bid, queue_size=10)

--- a/robonomics_lighthouse/src/robonomics_lighthouse/signer.py
+++ b/robonomics_lighthouse/src/robonomics_lighthouse/signer.py
@@ -46,7 +46,7 @@ def bidhash(msg):
 def reshash(msg):
     types = [ 'address'
             , 'bytes32' ]
-    return Web3.soliditySha3(types, [msg.liability, msg.result])
+    return Web3.soliditySha3(types, [msg.liability, b58decode(msg.result)[2:]])
 
 class Signer:
     def __init__(self):


### PR DESCRIPTION
This pull request introduces the following features:
* New eth_account_address ROS parameter, which can be passed to all nodes, requiring Ethereum account for operation. Empty value by default means, that a node should use 0-th account, as it was before this improvement
* New enable_executor ROS parameter in liability.launch, which can be used to start Liability-related nodes without Executor. Default value is true.

This pull request fixes the following:
* Race condition, which took place in Executor rosbag recording
* Liability execution result was not sent in the separate topic, suitable for signing and sending to the IPFS