### PR TITLE
Catch ipfs provider adding error on result publication

### DIFF
--- a/robonomics_liability/src/robonomics_liability/executor.py
+++ b/robonomics_liability/src/robonomics_liability/executor.py
@@ -84,7 +84,12 @@ class Executor:
                     rospy.sleep(1)
 
                 recorder.stop()
-                msg.result = self.ipfs.add(result_file)['Hash']
+                ipfs_response = self.ipfs.add(result_file)
+                try:
+                    msg.result = ipfs_response['Hash']
+                except TypeError:
+                    rospy.logwarn('IPFS add proceeding error: %s', ipfs_response[1]['Message'])
+                    msg.result = ipfs_response[0]['Hash']
                 result_msg = Result()
                 result_msg.liability = msg.address
                 result_msg.result = msg.result


### PR DESCRIPTION
It's to prevent liability node crashes on result publication if IPFS provides proceeding add request with an error.