### PR TITLE
use web3 ws in ethereum_common and liability tests improvements

### DIFF
--- a/ethereum_common/launch/erc20.launch
+++ b/ethereum_common/launch/erc20.launch
@@ -1,5 +1,6 @@
 <launch>
   <arg name="web3_http_provider" default="http://127.0.0.1:8545" />
+  <arg name="web3_ws_provider" default="ws://127.0.0.1:8546" />
   <arg name="erc20_token" default="xrt.3.robonomics.eth"/>
   <arg name="factory_contract" default="factory.3.robonomics.eth" />
   <arg name="ens_contract" default="" />
@@ -9,6 +10,7 @@
   <group ns="eth">
     <node pkg="ethereum_common" type="erc20_node" name="erc20_token" respawn="true" output="screen">
       <param name="web3_http_provider" value="$(arg web3_http_provider)" />
+      <param name="web3_ws_provider" value="$(arg web3_ws_provider)" />
       <param name="token_contract" value="$(arg erc20_token)" />
       <param name="ens_contract" value="$(arg ens_contract)"
              if="$(eval len(arg('ens_contract')) > 0)"/>
@@ -19,6 +21,7 @@
 
     <node pkg="ethereum_common" type="eth_node" name="eth_node" respawn="true" output="screen">
       <param name="web3_http_provider" value="$(arg web3_http_provider)" />
+      <param name="web3_ws_provider" value="$(arg web3_ws_provider)" />
       <param name="token_contract" value="$(arg erc20_token)" />
       <param name="ens_contract" value="$(arg ens_contract)"
              if="$(eval len(arg('ens_contract')) > 0)"/>

--- a/ethereum_common/src/ethereum_common/erc20_services.py
+++ b/ethereum_common/src/ethereum_common/erc20_services.py
@@ -21,10 +21,12 @@ class ERC20Services:
 
         self.eth_utils = ETHUtils(self.__account,
                                   rospy.get_param('~web3_http_provider'),
+                                  rospy.get_param('~web3_ws_provider'),
                                   rospy.get_param('~ens_contract', None),
                                   rospy.get_param('~token_contract'),
                                   XRT_ABI)
         self.erc20 = self.eth_utils.erc20Contract
+        self.erc20_ws = self.eth_utils.erc20ContractWS
         self.factory_address = self.eth_utils.getAddressByName(rospy.get_param('~factory_contract'))
 
         self.initialize_event_filters()
@@ -81,8 +83,8 @@ class ERC20Services:
 
     def initialize_event_filters(self):
         try:
-            self.transfer_filter = self.erc20.eventFilter('Transfer')
-            self.approval_filter = self.erc20.eventFilter('Approval')
+            self.transfer_filter = self.erc20_ws.eventFilter('Transfer')
+            self.approval_filter = self.erc20_ws.eventFilter('Approval')
         except Exception as e:
             rospy.logwarn("Failed to reinitialize erc20 event filters with exception: \"%s\"", e)
 

--- a/ethereum_common/src/ethereum_common/eth_services.py
+++ b/ethereum_common/src/ethereum_common/eth_services.py
@@ -15,8 +15,9 @@ class ETHServices:
         self.__account = __keyfile_helper.get_local_account_from_keyfile()
 
         self.eth_utils = ETHUtils(self.__account,
-                                        rospy.get_param('~web3_http_provider'),
-                                        rospy.get_param('~ens_contract', None))
+                                  rospy.get_param('~web3_http_provider'),
+                                  rospy.get_param('~web3_ws_provider'),
+                                  rospy.get_param('~ens_contract', None))
 
         def accounts_handler(m):
             return AccountsResponse([type_converter.strToAddress(self.__account.address)])

--- a/ethereum_common/src/ethereum_common/eth_utils.py
+++ b/ethereum_common/src/ethereum_common/eth_utils.py
@@ -1,12 +1,15 @@
-from web3 import Web3, HTTPProvider
+from web3 import Web3, HTTPProvider, WebsocketProvider
 from ens import ENS
 
 
 class ETHUtils:
-    def __init__(self, account, web3_http_provider, ens_contract, erc20_token=None, abi=None):
+    def __init__(self, account, web3_http_provider, web3_ws_provider, ens_contract, erc20_token=None, abi=None):
         http_provider = HTTPProvider(web3_http_provider)
         self.ens = ENS(http_provider,  addr=ens_contract)
         self.web3 = Web3(http_provider, ens=self.ens)
+
+        ws_provider = WebsocketProvider(web3_ws_provider)
+        self.web3ws = Web3(ws_provider, ens=self.ens)
 
         from web3.middleware import geth_poa_middleware
         # inject the poa compatibility middleware to the innermost layer
@@ -16,6 +19,7 @@ class ETHUtils:
         if erc20_token is not None and abi is not None:
             token_address = self.ens.address(erc20_token)
             self.erc20 = self.web3.eth.contract(token_address, abi=abi)
+            self.erc20_ws = self.web3ws.eth.contract(token_address, abi=abi)
             self.erc20_balance_delimiter = (10 ** self.erc20.functions.decimals().call())
 
         self.__account = account
@@ -23,6 +27,10 @@ class ETHUtils:
     @property
     def erc20Contract(self):
         return self.erc20
+
+    @property
+    def erc20ContractWS(self):
+        return self.erc20_ws
 
     @property
     def getCurrentBlockNumber(self):

--- a/robonomics_liability/tests/liability.test
+++ b/robonomics_liability/tests/liability.test
@@ -16,7 +16,6 @@
   </test>
 
   <test test-name="test_player" pkg="robonomics_liability" type="test_player.py" time-limit="300.0">
-    <param name="ipfs_http_provider" value="$(arg ipfs_http_provider)" />
   </test>
 
   <test test-name="test_recorder" pkg="robonomics_liability" type="test_recorder.py" time-limit="300.0">

--- a/robonomics_liability/tests/liability.test
+++ b/robonomics_liability/tests/liability.test
@@ -1,13 +1,16 @@
 <launch>
   <!-- arguments -->
+  <arg name="web3_http_provider" default="http://127.0.0.1:8545" />
   <arg name="ipfs_http_provider" default="http://127.0.0.1:5001" />
+  <arg name="lighthouse_contract" default="airalab.lighthouse.3.robonomics.eth" />
+  <arg name="ens_contract" default="" />
 
-  <arg name="lighthouse_contract_address" default="" />
   <arg name="test_token" default="" />
 
-
   <test test-name="test_executor" pkg="robonomics_liability" type="test_executor.py" time-limit="900.0">
-    <param name="lighthouse_contract_address" value="$(arg lighthouse_contract_address)" />
+    <param name="web3_http_provider" value="$(arg web3_http_provider)" />
+    <param name="ens_contract" value="$(arg ens_contract)" />
+    <param name="lighthouse_contract" value="$(arg lighthouse_contract)" />
     <param name="ipfs_http_provider" value="$(arg ipfs_http_provider)" />
     <param name="test_token" value="$(arg test_token)" />
   </test>

--- a/robonomics_liability/tests/test_executor.py
+++ b/robonomics_liability/tests/test_executor.py
@@ -47,6 +47,26 @@ class TestExecutor(unittest.TestCase):
         self.success = False
         self.ready_liability = None
 
+        self.test_objective = self.create_test_objective()
+        rospy.logwarn("TEST EXECUTOR: CURRENT OBJECTIVE is %s", self.test_objective)
+
+
+    def create_test_objective(self):
+        with TemporaryDirectory() as tmpdir:
+            os.chdir(tmpdir)
+            test_objective_bag = rosbag.Bag('output.bag', 'w')
+            email_data = String(data='test@mail')
+            droneid_data = String(data='test_drone_000')
+
+            test_objective_bag.write('/agent/objective/droneid', droneid_data, rospy.Time().now())
+            test_objective_bag.write('/agent/objective/email', email_data, rospy.Time().now())
+
+            test_objective_bag.close()
+
+            ipfs_objective = self.ipfs.add(test_objective_bag.filename)
+            rospy.logwarn("TEST_EXECUTOR: ADD TEST OBJECTIVE TO IPFS is %s", ipfs_objective)
+            return ipfs_objective['Hash']
+
     def ready_liability_handler(self, msg):
         self.ready_liability = msg
         rospy.loginfo("READY LIABILITY HANDLER: address is %s", self.ready_liability.address)
@@ -105,7 +125,7 @@ class TestExecutor(unittest.TestCase):
     def get_test_bid(self):
         bidDict = {
             "model": "QmaRmbJtyfMDBfkDETTPAxKUUcSqZKXWwFKKoZ318nrPku",
-            "objective": "Qmb3H3tHZ1QutcrLq7WEtQWbEWjA11aPqVmeatMSrmFXvE",
+            "objective": self.test_objective,
             "token": self.test_token,
             "cost": 0,
             "validator": '0x0000000000000000000000000000000000000000',
@@ -133,7 +153,7 @@ class TestExecutor(unittest.TestCase):
     def get_test_ask(self):
         askDict = {
             "model": "QmaRmbJtyfMDBfkDETTPAxKUUcSqZKXWwFKKoZ318nrPku",
-            "objective": "Qmb3H3tHZ1QutcrLq7WEtQWbEWjA11aPqVmeatMSrmFXvE",
+            "objective": self.test_objective,
             "token": self.test_token,
             "cost": 0,
             "lighthouse": self.lighthouse_address,

--- a/robonomics_liability/tests/test_player.py
+++ b/robonomics_liability/tests/test_player.py
@@ -2,15 +2,15 @@
 
 import rospy, rostest, rosbag
 import sys, os, time
-import ipfsapi, unittest
+import unittest
 
-from robonomics_liability.player import Player, get_rosbag_from_file
+from robonomics_liability.player import Player
 from tempfile import TemporaryDirectory
 from urllib.parse import urlparse
+from std_msgs.msg import *
 
 PKG = 'robonomics_liability'
 NAME = 'test_player'
-TEST_ROSBAG = 'Qmb3H3tHZ1QutcrLq7WEtQWbEWjA11aPqVmeatMSrmFXvE'
 
 
 class TestPlayer(unittest.TestCase):
@@ -18,8 +18,6 @@ class TestPlayer(unittest.TestCase):
     def __init__(self, *args):
         rospy.init_node(NAME)
         super(TestPlayer, self).__init__(*args)
-        ipfs_provider = urlparse(rospy.get_param('~ipfs_http_provider')).netloc.split(':')
-        self.ipfs = ipfsapi.connect(ipfs_provider[0], int(ipfs_provider[1]))
         self.subscribers_msg_counters = {}
 
     def decrement_subscriber_msg_counter(self, topic):
@@ -30,8 +28,16 @@ class TestPlayer(unittest.TestCase):
     def test_player(self):
         with TemporaryDirectory() as tmpdir:
             os.chdir(tmpdir)
-            self.ipfs.get(TEST_ROSBAG)
-            bag = get_rosbag_from_file(TEST_ROSBAG)
+
+            test_bag = rosbag.Bag('output.bag', 'w')
+            email_data = String(data='test@mail')
+            droneid_data = String(data='test_drone_000')
+            test_bag.write('/agent/objective/droneid', droneid_data, rospy.Time().now())
+            test_bag.write('/agent/objective/email', email_data, rospy.Time().now())
+            test_bag.close()
+
+            bag = rosbag.Bag('output.bag', 'r')
+
             subscribers = {}
 
             bag_topics = bag.get_type_and_topic_info()


### PR DESCRIPTION
use web3 ws provider in ethereum_common services
use lighthouse_contract in test_executor
liability tests: generate rosbag in tests instead of getting from ipfs