### PR TITLE
Introduced liabilities execution timestamp persistence and restart/resume ros-services

### DIFF
--- a/robonomics_liability/CMakeLists.txt
+++ b/robonomics_liability/CMakeLists.txt
@@ -15,6 +15,7 @@ catkin_python_setup()
 add_message_files(
     FILES
         Liability.msg
+        LiabilityExecutionTimestamp.msg
 )
 
 ## Generate services in the 'srv' folder
@@ -23,6 +24,7 @@ add_service_files(
         FinishLiability.srv
         StartLiability.srv
         PersistenceContainsLiability.srv
+        PersistenceLiabilityTimestamp.srv
 )
 
 generate_messages(

--- a/robonomics_liability/launch/liability.launch
+++ b/robonomics_liability/launch/liability.launch
@@ -12,6 +12,8 @@
   <arg name="keyfile" default="" />
   <arg name="keyfile_password_file" default="" />
 
+  <arg name="persistence_update_interval" default='0.1' />
+
   <arg name="enable_aira_graph" default="true" />
   <arg name="graph_topic" default="graph.4.robonomics.eth" />
   <arg name="lighthouse_topic" default="airalab.lighthouse.4.robonomics.eth" />
@@ -63,6 +65,7 @@
     </node>
 
     <node pkg="robonomics_liability" type="persistence_node" name="persistence" respawn="true" output="screen">
+      <param name="persistence_update_interval" value="$(arg persistence_update_interval)" />
     </node>
   </group>
 </launch>

--- a/robonomics_liability/msg/LiabilityExecutionTimestamp.msg
+++ b/robonomics_liability/msg/LiabilityExecutionTimestamp.msg
@@ -1,0 +1,2 @@
+ethereum_common/Address address
+time timestamp

--- a/robonomics_liability/src/robonomics_liability/LiabilityExecutionThread.py
+++ b/robonomics_liability/src/robonomics_liability/LiabilityExecutionThread.py
@@ -1,37 +1,35 @@
 import threading
 
 from robonomics_msgs.msg import Result
-from ipfs_common.msg import Multihash
 from .player import Player, get_rosbag_from_file
 from .recorder import Recorder
-from tempfile import TemporaryDirectory
 import rospy, os
 
 
 class LiabilityExecutionThread(object):
-    def __init__(self, ipfs_client, master_check_interval, recording_topics, liability):
+    def __init__(self, work_directory, ipfs_client, master_check_interval, recording_topics, liability):
 
+        self.work_directory = work_directory
         self.ipfs_client = ipfs_client
         self.master_check_interval = master_check_interval
         self.recording_topics = recording_topics
 
         self.liability = liability
+        self.thread = None
 
-        self.thread = threading.Thread(target=self.__execute_liability, args=())
-        self.thread.daemon = True
-
-        self.__recorder = None
-        self.__player = None
-        self.__liability_result_file = None
         self.__liability_execution_namespace = "eth_{0}".format(self.liability.address.address)
+        self.__liability_result_file = os.path.join(self.work_directory, 'result.bag')
 
-        self.tmp_directory = TemporaryDirectory()
-        rospy.logdebug('Temporary directory created: %s', self.tmp_directory.name)
+        self.__player = self.__initializePlayer()
+        self.__recorder = self.__initializeRecorder()
 
     def getLiabilityMsg(self):
         return self.liability
 
-    def start(self):
+    def start(self, timestamp=None):
+        rospy.loginfo("Liability execution thread start called: %s with timestamp %s", self.liability.address.address, timestamp)
+        self.thread = threading.Thread(target=self.__execute_liability, args=(timestamp,))
+        self.thread.daemon = True
         self.thread.start()
 
     def finish(self, success):
@@ -51,32 +49,46 @@ class LiabilityExecutionThread(object):
         result_msg.success = success
         return result_msg
 
-    def __createRecorder(self, result_file):
-        recorder = Recorder(result_file,
-                            topics=self.recording_topics,
-                            namespace="/liability/{0}".format(self.__liability_execution_namespace),
-                            master_check_interval=self.master_check_interval)
-        return recorder
+    def interrupt(self, delete_result=True):
+        if self.thread.isAlive():
+            self.__recorder.stop()
+            self.__player.stop()
+            if delete_result is True and os.path.exists(self.__liability_result_file) :
+                os.remove(self.__liability_result_file)
 
-    def __execute_liability(self):
-        os.chdir(self.tmp_directory.name)
-        
+    def __initializeRecorder(self):
+        __recorder = Recorder(self.__liability_result_file,
+                              topics=self.recording_topics,
+                              namespace="/liability/{0}".format(self.__liability_execution_namespace),
+                              master_check_interval=self.master_check_interval)
+        return __recorder
+
+    def __initializePlayer(self):
+        os.chdir(self.work_directory)
+
         rospy.logdebug('Getting objective %s...', self.liability.objective.multihash)
         self.ipfs_client.get(self.liability.objective.multihash)
-        rospy.logdebug('Objective is written to %s', self.tmp_directory.name + '/' + self.liability.objective.multihash)
-
-        self.__liability_result_file = os.path.join(self.tmp_directory.name, 'result.bag')
-        rospy.logdebug('Start recording to %s...', self.__liability_result_file)
-        rospy.logdebug("Recording all topics: %s", (not self.recording_topics))
-
-        self.__recorder = self.__createRecorder(self.__liability_result_file)
-        self.__recorder.start()
-        rospy.logdebug('Rosbag recorder started')
+        rospy.logdebug('Objective is written to %s',
+                       self.work_directory + '/' + self.liability.objective.multihash)
 
         objective_rosbag = get_rosbag_from_file(self.liability.objective.multihash)
         if objective_rosbag is not None:
-            self.__player = Player(objective_rosbag, self.__liability_execution_namespace)
-            self.__player.start()
-            rospy.logdebug('Rosbag player started')
+            __player = Player(objective_rosbag, self.liability.address, self.__liability_execution_namespace)
+            return __player
+        else:
+            rospy.logwarn('rosbag player in liability %s is not created', self.liability.address)
+            return None
+
+    def __execute_liability(self, resume_from_timestamp):
+        rospy.logdebug('Start recording to %s in liability %s...',
+                       self.__liability_result_file, self.liability.address.address)
+        rospy.logdebug("Recording all topics: %s", (not self.recording_topics))
+
+        self.__recorder.start()
+        rospy.logdebug('Rosbag recorder started in liability %s', self.liability.address.address)
+
+        if self.__player is not None:
+            self.__player.start(resume_from_timestamp)
+            rospy.logdebug('Rosbag player started in liability %s', self.liability.address.address)
         else:
             rospy.logwarn('Skip playing objective using rosbag player in liability %s', self.liability.address)

--- a/robonomics_liability/src/robonomics_liability/LiabilityExecutionsPersistence.py
+++ b/robonomics_liability/src/robonomics_liability/LiabilityExecutionsPersistence.py
@@ -1,7 +1,8 @@
 import rospy, shelve, time
-from threading import Lock
-from robonomics_liability.msg import Liability
-from robonomics_liability.srv import PersistenceContainsLiability, PersistenceContainsLiabilityResponse
+from threading import Lock, Timer
+from robonomics_liability.msg import Liability, LiabilityExecutionTimestamp
+from robonomics_liability.srv import PersistenceContainsLiability, PersistenceContainsLiabilityResponse, PersistenceLiabilityTimestamp, PersistenceLiabilityTimestampResponse
+from persistent_queue import PersistentQueue
 
 
 class LiabilityExecutionsPersistence:
@@ -10,33 +11,71 @@ class LiabilityExecutionsPersistence:
             Robonomics liability persistence node initialisation.
         """
         rospy.init_node('robonomics_liability_persistence')
+        self.persistence_update_interval = rospy.get_param('~persistence_update_interval', 0.1)
 
         self.__liability_executions_lock = Lock()
-        self.__liability_executions = shelve.open("robonomics_liability_executions.persistence")
+        self.__liability_timestamps_lock = Lock()
 
-        self.__incoming_liability_topic = rospy.Publisher('incoming', Liability, queue_size=10)
-
-        self.__restart_executions()
+        self.__liability_executions            = shelve.open("robonomics_liability_executions.persistence")
+        self.__liability_executions_timestamps = shelve.open("robonomics_liability_executions_timestamps.persistence")
+        self.__liability_executions_timestamps_queue = PersistentQueue('robonomics_liability_executions_timestamps.queue')
 
         rospy.Subscriber('persistence/add', Liability, self.__add_liability)
         rospy.Subscriber('persistence/del', Liability, self.__del_liability)
-
+        rospy.Subscriber("persistence/update_timestamp", LiabilityExecutionTimestamp,
+                         self.__update_liability_execution_timestamp_handler)
         rospy.Service("persistence/exists", PersistenceContainsLiability, self.__liability_exists)
+        rospy.Service("persistence/get_liability_timestamp", PersistenceLiabilityTimestamp, self.__get_liability_timestamp)
+
+        self.__incoming_liability_topic = rospy.Publisher('incoming', Liability, queue_size=10)
+        self.__restore_executions()
+
+    def __update_liability_execution_timestamp_handler(self, msg):
+        self.__liability_executions_timestamps_queue.push(msg)
+
+    def __update_liability_execution_timestamp(self, msg):
+        rospy.logdebug("update liability %s execution timestamp", msg.address.address)
+        if msg.address.address not in self.__liability_executions_timestamps:
+            rospy.logwarn("liability %s already unregistered from timestamps persistence",
+                          msg.address.address)
+            return
+
+        try:
+            self.__liability_timestamps_lock.acquire()
+            self.__liability_executions_timestamps[msg.address.address] = msg.timestamp
+            self.__liability_executions_timestamps.sync()
+        finally:
+            self.__liability_timestamps_lock.release()
+        rospy.logdebug("Persistence liability %s timestamp %s",
+                       msg.address.address,
+                       self.__liability_executions_timestamps[msg.address.address])
 
     def __liability_exists(self, msg):
         return PersistenceContainsLiabilityResponse(msg.address in self.__liability_executions)
+
+    def __register_liability_in_timestamp_persistence(self, msg):
+        try:
+            self.__liability_timestamps_lock.acquire()
+            if msg.address.address not in self.__liability_executions_timestamps:
+                self.__liability_executions_timestamps[msg.address.address] = rospy.Time.from_sec(0)
+            rospy.loginfo("Timestamps persistence contains %s value for liability %s",
+                          self.__liability_executions_timestamps[msg.address.address],
+                          msg.address.address)
+            self.__liability_executions_timestamps.sync()
+        finally:
+            self.__liability_timestamps_lock.release()
 
     def __add_liability(self, msg):
         try:
             self.__liability_executions_lock.acquire()
             self.__liability_executions[msg.address.address] = msg
+            self.__register_liability_in_timestamp_persistence(msg)
             self.__liability_executions.sync()
             rospy.loginfo("Liability %s added to liabilities executions persistence store", msg.address.address)
         finally:
             self.__liability_executions_lock.release()
 
     def __del_liability(self, msg):
-
         try:
             self.__liability_executions_lock.acquire()
             del self.__liability_executions[msg.address.address]
@@ -47,7 +86,17 @@ class LiabilityExecutionsPersistence:
         finally:
             self.__liability_executions_lock.release()
 
-    def __restart_executions(self):
+        try:
+            self.__liability_timestamps_lock.acquire()
+            del self.__liability_executions_timestamps[msg.address.address]
+            self.__liability_executions_timestamps.sync()
+            rospy.loginfo("Liability %s deleted from liabilities timestamps persistence store", msg.address.address)
+        except KeyError:
+            rospy.logwarn("Liability %s not found in liabilities timestamps persistence store", msg.address.address)
+        finally:
+            self.__liability_timestamps_lock.release()
+
+    def __restore_executions(self):
         try:
             self.__liability_executions_lock.acquire()
             executions = list(self.__liability_executions.values())
@@ -57,7 +106,32 @@ class LiabilityExecutionsPersistence:
         time.sleep(5)
         for liability in executions:
             self.__incoming_liability_topic.publish(liability)
-            rospy.logwarn("Liability %s received from liabilities executions persistence store", liability.address.address)
+            rospy.logwarn("Liability %s received from liabilities executions persistence store",
+                          liability.address.address)
+
+    def __get_liability_timestamp(self, msg):
+        timestamp = rospy.Time.from_sec(0)
+        liability_address = msg.address.address
+        queue_entry = self.__liability_executions_timestamps_queue.peek()
+        while queue_entry is not None:
+            time.sleep(0.1)
+            queue_entry = self.__liability_executions_timestamps_queue.peek()
+        try:
+            self.__liability_timestamps_lock.acquire()
+            timestamp = self.__liability_executions_timestamps[liability_address]
+        except KeyError as e:
+            rospy.logwarn("Unable to get known execution timestamp for liability %s", liability_address)
+        finally:
+            self.__liability_timestamps_lock.release()
+        return PersistenceLiabilityTimestampResponse(timestamp)
 
     def spin(self):
+        def update_liability_timestamp_queue_handler():
+            entry = self.__liability_executions_timestamps_queue.peek()
+            if entry is not None:
+                self.__update_liability_execution_timestamp(entry)
+                self.__liability_executions_timestamps_queue.pop()
+            Timer(self.persistence_update_interval, update_liability_timestamp_queue_handler).start()
+
+        update_liability_timestamp_queue_handler()
         rospy.spin()

--- a/robonomics_liability/src/robonomics_liability/executor.py
+++ b/robonomics_liability/src/robonomics_liability/executor.py
@@ -4,7 +4,7 @@
 #
 
 from robonomics_liability.msg import Liability
-from robonomics_liability.srv import FinishLiability, FinishLiabilityResponse, StartLiability, StartLiabilityResponse
+from robonomics_liability.srv import FinishLiability, FinishLiabilityResponse, StartLiability, StartLiabilityResponse, PersistenceLiabilityTimestamp
 from robonomics_msgs.msg import Result
 from urllib.parse import urlparse
 from threading import Thread
@@ -12,6 +12,8 @@ from .LiabilityExecutionThread import LiabilityExecutionThread
 from queue import Queue
 import rospy, ipfsapi
 from ethereum_common import eth_keyfile_helper
+import os
+
 
 class Executor:
     liability_queue = Queue()
@@ -39,6 +41,10 @@ class Executor:
         #persistence publishers
         self.persistence_add = rospy.Publisher('persistence/add', Liability, queue_size=10)
         self.persistence_del = rospy.Publisher('persistence/del', Liability, queue_size=10)
+        #persistence services
+        self.persistence_get_liability_timestamp = rospy.ServiceProxy('persistence/get_liability_timestamp', PersistenceLiabilityTimestamp)
+
+        self.executions_work_directory = os.path.join(os.getcwd(), 'liabilities_executions')
 
         def incoming_liability(msg):
             if msg.promisor.address != self.__account.address:
@@ -75,12 +81,66 @@ class Executor:
                 rospy.logerr("Can't start liability %s with %s", msg.address, e)
                 return StartLiabilityResponse(False, "Can't start liability {0} with exception: {1}".format(msg.address, e))
 
-            return StartLiabilityResponse(True, "Liability {0} started".format(liability_thread.getLiabilityMsg().address))
+            return StartLiabilityResponse(True, "Liability {0} started".format(liability_thread.getLiabilityMsg().address.address))
         rospy.Service('start', StartLiability, start_liability)
 
-        self.complete = rospy.Publisher('complete', Liability, queue_size=10)
-        self.ready  = rospy.Publisher('ready', Liability, queue_size=10)
+        def restart_liability(msg):
+            try:
+                liability_thread = self.liability_execution_threads.pop(msg.address)
+            except KeyError as e:
+                rospy.logerr("Could not find liability %s for restarting", msg.address)
+                return StartLiabilityResponse(False, "Could not find liability {0} for restarting".format(msg.address))
+
+            liability = liability_thread.getLiabilityMsg()
+            try:
+                liability_thread.interrupt(delete_result=True)
+                rospy.loginfo('Liability %s interrupted', liability.address)
+            except Exception as e:
+                rospy.logerr("Can't interrupt liability %s with %s", msg.address, e)
+                return StartLiabilityResponse(False,
+                                              "Can't interrupt liability {0} with exception: {1}".format(msg.address, e))
+            try:
+                self._createLiabilityExceutionThread(liability)
+            except Exception as e:
+                return StartLiabilityResponse(False, "Can't initialize liability {0} execution thread with exception: {1}".format(msg.address, e))
+            return start_liability(msg)
+        rospy.Service('restart', StartLiability, restart_liability)
+
+        def resume_liability(msg):
+            try:
+                liability_thread = self.liability_execution_threads[msg.address]
+            except KeyError as e:
+                rospy.logerr("Could not find liability %s for resuming", msg.address)
+                return StartLiabilityResponse(False, "Could not find liability {0} for resuming".format(msg.address))
+            try:
+                rospy.wait_for_service(self.persistence_get_liability_timestamp.resolved_name)
+                timestamp = self.persistence_get_liability_timestamp(liability_thread.getLiabilityMsg().address)
+                rospy.logwarn("Getting %s timestamp for liability %s", timestamp.timestamp, msg.address)
+                liability_thread.start(timestamp.timestamp)
+                rospy.loginfo('Liability %s resumed', liability_thread.getLiabilityMsg().address)
+            except Exception as e:
+                rospy.logerr("Can't resume liability %s with %s", msg.address, e)
+                return StartLiabilityResponse(False, "Can't resume liability {0} with exception: {1}".format(msg.address, e))
+
+            return StartLiabilityResponse(True, "Liability {0} resumed".format(liability_thread.getLiabilityMsg().address.address))
+        rospy.Service('resume', StartLiability, resume_liability)
+
+
+        self.complete =     rospy.Publisher('complete', Liability, queue_size=10)
+        self.ready  =       rospy.Publisher('ready', Liability, queue_size=10)
         self.result_topic = rospy.Publisher('result', Result, queue_size=10)
+
+    def _createLiabilityExceutionThread(self, liability):
+        liability_work_directory = os.path.join(self.executions_work_directory, liability.address.address)
+        os.makedirs(liability_work_directory, exist_ok=True)
+        rospy.loginfo('Use directory %s for liability %s executor thread',
+                      liability_work_directory, liability.address.address)
+        thread = LiabilityExecutionThread(liability_work_directory,
+                                          self.ipfs_client,
+                                          self.master_check_interval,
+                                          self.recording_topics,
+                                          liability)
+        self.liability_execution_threads[liability.address.address] = thread
 
     def _liability_worker(self):
         while not rospy.is_shutdown():
@@ -88,8 +148,7 @@ class Executor:
             rospy.loginfo('Prepare to start liability %s', msg.address.address)
 
             try:
-                thread = LiabilityExecutionThread(self.ipfs_client, self.master_check_interval, self.recording_topics, msg)
-                self.liability_execution_threads[msg.address.address] = thread
+                self._createLiabilityExceutionThread(msg)
                 self.ready.publish(msg)
             except Exception as e:
                 rospy.logerr("Failed to prepare liability execution thread for %s with exception \"%s\"", msg.address, e)

--- a/robonomics_liability/src/robonomics_liability/player.py
+++ b/robonomics_liability/src/robonomics_liability/player.py
@@ -2,6 +2,7 @@
 
 import rospy, rosbag
 from threading import Thread
+from robonomics_liability.msg import LiabilityExecutionTimestamp
 
 
 def get_rosbag_from_file(filename):
@@ -9,14 +10,18 @@ def get_rosbag_from_file(filename):
         bag = rosbag.Bag(filename, 'r')
         return bag
     except Exception as e:
-        rospy.logwarn("Failed to get rosbag topics info from file %s with exception: \"%s\"", filename, e)
+        rospy.logerr("Failed to get rosbag topics info from file %s with exception: \"%s\"", filename, e)
         return None
 
 
 class Player:
-    def __init__(self, bag, namespace=''):
+    def __init__(self, bag, address, namespace=''):
+        self.liability_address = address
         self.namespace = namespace
         self.pubs = {}
+        self.start_timestamp = None
+
+        self.__update_timestamp = rospy.Publisher("persistence/update_timestamp", LiabilityExecutionTimestamp, queue_size=10)
 
         try:
             self.publisher = Thread(target=self.simple_publisher, daemon=True, args=(bag.read_messages(),))
@@ -25,20 +30,25 @@ class Player:
             rospy.logerr('Player exception: %s', e)
 
     def simple_publisher(self, msgs):
-
-        for topic, msg, _ in msgs:
+        for topic, msg, timestamp in msgs:
             if not topic in self.pubs:
                 rospy.logdebug('New publisher %s of %s', topic, msg.__class__)
                 self.pubs[topic] = rospy.Publisher(self.namespace + topic, msg.__class__, queue_size=10)
                 rospy.sleep(1)
 
-            rospy.logdebug('Publish message %s to %s', msg, topic)
-            self.pubs[topic].publish(msg)
+            if self.start_timestamp is None or timestamp > self.start_timestamp:
+                rospy.logdebug('Publish message %s to %s', msg, topic)
+                self.pubs[topic].publish(msg)
+                tmstpm_msg = LiabilityExecutionTimestamp()
+                tmstpm_msg.address = self.liability_address
+                tmstpm_msg.timestamp = timestamp
+                self.__update_timestamp.publish(tmstpm_msg)
 
         rospy.sleep(5)
         rospy.logdebug('Publish done')
 
-    def start(self):
+    def start(self, timestamp):
+        self.start_timestamp = timestamp
         self.publisher.start()
         rospy.logdebug('Player started')
 

--- a/robonomics_liability/srv/PersistenceLiabilityTimestamp.srv
+++ b/robonomics_liability/srv/PersistenceLiabilityTimestamp.srv
@@ -1,0 +1,3 @@
+ethereum_common/Address address
+---
+time timestamp

--- a/robonomics_liability/tests/test_player.py
+++ b/robonomics_liability/tests/test_player.py
@@ -57,8 +57,9 @@ class TestPlayer(unittest.TestCase):
 
             time.sleep(3)
             rospy.loginfo("Start player")
-            player = Player(bag)
-            player.start()
+            test_player_start_timestamp = rospy.Time.from_sec(0)
+            player = Player(bag, "0x0000000000000000000000000000000000000000")
+            player.start(test_player_start_timestamp)
             time.sleep(3)
 
             for topic in self.subscribers_msg_counters:


### PR DESCRIPTION
#62
new services:
-  /liability/restart -- restart not-finished liability from first liability objective rosbag message
-  /liability/resume -- resume liability execution from latest published liability objective rosbag message (timestamp of latest published message will be extracted from liabilities timestamps persistence)