### PR TITLE
Arithmetic for UInt256

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -2,6 +2,7 @@
 , ros_comm
 , mkRosPackage
 , python3Packages
+, python3
 }:
 
 mkRosPackage rec {
@@ -13,6 +14,10 @@ mkRosPackage rec {
 
   propagatedBuildInputs = with python3Packages;
   [ ros_comm web3 multihash voluptuous ipfsapi python-persistent-queue ];
+
+  postInstall = ''
+    patch $out/lib/${python3.libPrefix}/site-packages/ethereum_common/msg/_UInt256.py $src/ethereum_common/msg/_UInt256.py.patch
+  '';
 
   meta = with stdenv.lib; {
     description = "Robonomics communication stack";

--- a/ethereum_common/msg/_UInt256.py.patch
+++ b/ethereum_common/msg/_UInt256.py.patch
@@ -1,0 +1,54 @@
+--- _UInt256.py	2019-01-16 10:50:03.382925478 +0300
++++ _UInt256.py	2019-01-16 10:51:23.251234649 +0300
+@@ -5,6 +5,7 @@
+ import genpy
+ import struct
+ 
++UINT256_MAX_VALUE = 2**256 - 1
+ 
+ class UInt256(genpy.Message):
+   _md5sum = "d3e47bf4311da2c63d362b5eea4c389b"
+@@ -117,6 +118,43 @@
+     except struct.error as e:
+       raise genpy.DeserializationError(e) #most likely buffer underfill
+ 
++  def __add__(self, other):
++      if isinstance(other, int):
++          self_int = int(self.uint256)
++          result_int = self_int + other
++          if result_int > UINT256_MAX_VALUE:
++              raise OverflowError("Result is larger then UInt256")
++          return UInt256(str(result_int))
++      elif isinstance(other, UInt256):
++          self_int = int(self.uint256)
++          other_int = int(other.uint256)
++          result_int = self_int + other_int
++          if result_int > UINT256_MAX_VALUE:
++              raise OverflowError("Result is larger then UInt256")
++          return UInt256(str(result_int))
++      else:
++          raise TypeError("unexpected value: %s with type %s", other, type(other))
++
++  def __iadd__(self, other):
++      if isinstance(other, int):
++          self_int = int(self.uint256)
++          result_int = self_int + other
++          if result_int > UINT256_MAX_VALUE:
++              raise OverflowError("Result is larger then UInt256")
++          self.uint256 = str(result_int)
++          return self
++      elif isinstance(other, UInt256):
++          self_int = int(self.uint256)
++          other_int = int(other.uint256)
++          result_int = self_int + other_int
++          if result_int > UINT256_MAX_VALUE:
++              raise OverflowError("Result is larger then UInt256")
++          self.uint256 = str(result_int)
++          return self
++      else:
++          raise TypeError("unexpected value: %s with type %s", other, type(other))
++
++
+ _struct_I = genpy.struct_I
+ def _get_struct_I():
+     global _struct_I

--- a/ethereum_common/src/ethereum_common/erc20_services.py
+++ b/ethereum_common/src/ethereum_common/erc20_services.py
@@ -1,5 +1,5 @@
 from web3 import Web3
-from ethereum_common.msg import *
+from ethereum_common.msg import ApprovalEvent, TransferEvent
 from ethereum_common.srv import *
 from threading import Timer
 from json import loads

--- a/ethereum_common/src/ethereum_common/type_converters.py
+++ b/ethereum_common/src/ethereum_common/type_converters.py
@@ -1,14 +1,10 @@
-from ethereum_common.msg import *
+from ethereum_common.msg import Address, UInt256, ApprovalEvent, TransferEvent
 
 def strToAddress(s):
-    a = Address()
-    a.address = s
-    return a
+    return Address(s)
 
 def strToUInt256(s):
-    u = UInt256()
-    u.uint256 = str(s)
-    return u
+    return UInt256(str(s))
 
 def filterEntryToTransferEvent(args):
     m = TransferEvent()

--- a/robonomics_liability/tests/liability.test
+++ b/robonomics_liability/tests/liability.test
@@ -4,6 +4,8 @@
   <arg name="ipfs_http_provider" default="http://127.0.0.1:5001" />
   <arg name="lighthouse_contract" default="airalab.lighthouse.4.robonomics.eth" />
   <arg name="ens_contract" default="" />
+  <arg name="keyfile" default="" />
+  <arg name="keyfile_password_file" default="" />
 
   <arg name="test_token" default="" />
 
@@ -28,6 +30,8 @@
   </test>
 
   <test test-name="test_signer" pkg="robonomics_liability" type="test_signer.py" time-limit="300.0">
+    <param name="keyfile" value="$(arg keyfile)" />
+    <param name="keyfile_password_file" value="$(arg keyfile_password_file)" />
   </test>
 
 </launch>

--- a/robonomics_msgs/src/robonomics_msgs/robonomicsMessageUtils.py
+++ b/robonomics_msgs/src/robonomics_msgs/robonomicsMessageUtils.py
@@ -1,0 +1,72 @@
+# -*- coding: utf-8 -*-
+#
+# Robonomics Demand/Offer/Result message utils
+#
+from web3 import Web3
+from web3.auto import w3
+from robonomics_msgs.msg import Demand, Offer, Result
+from eth_account.messages import defunct_hash_message
+import multihash
+
+
+def demand_hash(msg):
+    types = ['bytes',
+             'bytes',
+             'address',
+             'uint256',
+             'address',
+             'address',
+             'uint256',
+             'uint256',
+             'bytes32']
+    return Web3.soliditySha3(types, [multihash.decode(msg.model.multihash.encode(), "base58").encode(),
+                                     multihash.decode(msg.objective.multihash.encode(), "base58").encode(),
+                                     msg.token.address,
+                                     int(msg.cost.uint256),
+                                     msg.lighthouse.address,
+                                     msg.validator.address,
+                                     int(msg.validatorFee.uint256),
+                                     int(msg.deadline.uint256),
+                                     msg.nonce])
+
+
+def offer_hash(msg):
+    types = ['bytes',
+             'bytes',
+             'address',
+             'uint256',
+             'address',
+             'address',
+             'uint256',
+             'uint256',
+             'bytes32']
+    return Web3.soliditySha3(types, [multihash.decode(msg.model.multihash.encode(), 'base58').encode(),
+                                     multihash.decode(msg.objective.multihash.encode(), 'base58').encode(),
+                                     msg.token.address,
+                                     int(msg.cost.uint256),
+                                     msg.validator.address,
+                                     msg.lighthouse.address,
+                                     int(msg.lighthouseFee.uint256),
+                                     int(msg.deadline.uint256),
+                                     msg.nonce])
+
+def result_hash(msg):
+    types = ['address',
+             'bytes',
+             'bool']
+    return Web3.soliditySha3(types, [msg.liability.address, multihash.decode(msg.result.multihash.encode(), 'base58').encode(), msg.success])
+
+
+def get_signer_account_address(msg):
+    if isinstance(msg, Demand):
+        message_hash = defunct_hash_message(demand_hash(msg))
+    elif isinstance(msg, Offer):
+        message_hash = defunct_hash_message(offer_hash(msg))
+    elif isinstance(msg, Result):
+        message_hash = defunct_hash_message(result_hash(msg))
+    else:
+        raise TypeError("Cannot get signer for message %s of type %s", msg, type(msg))
+
+    signature = msg.signature
+    recovered_hash = w3.eth.account.recoverHash(message_hash, signature=signature)
+    return recovered_hash


### PR DESCRIPTION
#88

After generation UInt256.msg to _UInt256.py type class _UInt256.py patch file robonomics_comm/ethereum_common/msg/_UInt256.py.patch must be applied.

In case of robonomics_comm building with nix, this patch applied automatically.

In case of robonomics_comm building with standard ROS tools (catkin_init_workspace and catkin_make) patch must be applied manually:

```bash
patch ./devel/lib/python3.7/site-packages/ethereum_common/msg/_UInt256.py src/robonomics_comm/ethereum_common/msg/_UInt256.py.patch
```
