### PR TITLE
Support IPFS v0.6.0

### DIFF
--- a/fetchNixpkgs.nix
+++ b/fetchNixpkgs.nix
@@ -1,5 +1,5 @@
-{ rev    ? "f8c451acaa0495a00f507ef72da479f8789eda2c"             # The Git revision of nixpkgs to fetch
-, sha256 ? "0h8imd7zg6yx63yn06wb5ka75mwd3x90g41w2n1zvahx9gsrrdk7" # The SHA256 of the downloaded data
+{ rev    ? "907c71e6477831833cf0e81ef10202c0e9a253dd"             # The Git revision of nixpkgs to fetch
+, sha256 ? "0nlldjzjrs1zxz6s280q4lx9nb3n4jywhwmq5ngqfmkazg3nkj6d" # The SHA256 of the downloaded data
 }:
 
 builtins.fetchTarball {

--- a/ipfs_common/src/ipfs_common/ipfs_common.py
+++ b/ipfs_common/src/ipfs_common/ipfs_common.py
@@ -14,11 +14,7 @@ from ipfs_common.srv import IpfsUploadFile, IpfsDownloadFile, IpfsUploadFileRequ
 
 def build_client(provider_endpoint):
     rospy.loginfo("Build IPFS client: %s", provider_endpoint)
-    ipfs_url = urlparse(provider_endpoint)
-    ipfs_netloc = ipfs_url.netloc.split(':')
-    no_read_timeout = Timeout(read=None)
-    return ipfshttpclient.connect("/dns/{0}/tcp/{1}/{2}".format(ipfs_netloc[0], ipfs_netloc[1], ipfs_url.scheme),
-                                  session=True, timeout=no_read_timeout)
+    return ipfshttpclient.connect(provider_endpoint, session=True)
 
 
 class IPFSCommon:


### PR DESCRIPTION
IPFS v0.6.0 uses multiaddr by default meaning the endpoint must look like `/ip4/127.0.0.1/tcp/5001/http`
That said there is no point in parsing URL anymore 